### PR TITLE
Add missing length information for asset varchar columns

### DIFF
--- a/packages/server/src/assets/asset.entity.ts
+++ b/packages/server/src/assets/asset.entity.ts
@@ -6,7 +6,7 @@ import { MapsetEntity } from '../beatmap/mapset.entity';
 export class AssetEntity {
   @PrimaryGeneratedColumn('uuid')
   id: string;
-  @Column()
+  @Column({ type: 'varchar', length: 512 })
   path: string;
   @ManyToOne(() => MapsetEntity, {
     nullable: false,

--- a/packages/server/src/assets/s3-asset.entity.ts
+++ b/packages/server/src/assets/s3-asset.entity.ts
@@ -4,7 +4,7 @@ import { Column, Entity, PrimaryColumn } from 'typeorm';
 export class S3AssetEntity {
   @PrimaryColumn({ type: 'varchar' })
   key: string;
-  @Column({ type: 'varchar' })
+  @Column({ type: 'varchar', length: 64 })
   bucket: string;
   @Column({ type: 'int' })
   filesize: number;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the `AssetEntity` and `S3AssetEntity` classes to support longer `path` and `bucket` names, respectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->