### PR TITLE
Feat: Add beatmap snapshots

### DIFF
--- a/packages/server/src/beatmap/beatmap-snapshot.entity.ts
+++ b/packages/server/src/beatmap/beatmap-snapshot.entity.ts
@@ -20,6 +20,10 @@ export class BeatmapSnapshotEntity {
   @Index()
   timestamp: Date;
 
+  @Column('timestamp', { default: () => 'CURRENT_TIMESTAMP' })
+  @Index()
+  createDate: Date;
+
   @Column()
   version: number;
 

--- a/packages/server/src/beatmap/beatmap-snapshot.entity.ts
+++ b/packages/server/src/beatmap/beatmap-snapshot.entity.ts
@@ -16,10 +16,16 @@ export class BeatmapSnapshotEntity {
   @ManyToOne(() => BeatmapEntity)
   beatmap: BeatmapEntity;
 
+  /**
+   * The timestamp when this snapshot was last updated.
+   */
   @Column('timestamp', { default: () => 'CURRENT_TIMESTAMP' })
   @Index()
   timestamp: Date;
 
+  /**
+   * The timestamp when this snapshot was initially created.
+   */
   @Column('timestamp', { default: () => 'CURRENT_TIMESTAMP' })
   @Index()
   createDate: Date;

--- a/packages/server/src/beatmap/beatmap-snapshot.entity.ts
+++ b/packages/server/src/beatmap/beatmap-snapshot.entity.ts
@@ -1,0 +1,28 @@
+import {
+  Column,
+  Entity,
+  Index,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { BeatmapEntity } from './beatmap.entity';
+import { BeatmapData } from '@osucad/common';
+
+@Entity('beatmap_snapshot')
+export class BeatmapSnapshotEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => BeatmapEntity)
+  beatmap: BeatmapEntity;
+
+  @Column('timestamp', { default: () => 'CURRENT_TIMESTAMP' })
+  @Index()
+  timestamp: Date;
+
+  @Column()
+  version: number;
+
+  @Column('json')
+  data: BeatmapData;
+}

--- a/packages/server/src/beatmap/beatmap-snapshot.service.ts
+++ b/packages/server/src/beatmap/beatmap-snapshot.service.ts
@@ -29,7 +29,7 @@ export class BeatmapSnapshotService {
       });
 
       if (existingSnapshot) {
-        const age = existingSnapshot.timestamp.getTime() - Date.now();
+        const age = Date.now() - existingSnapshot.timestamp.getTime();
         if (age < this.snapshotCombineThreshold) {
           existingSnapshot.data = data;
           existingSnapshot.version = data.version ?? 1;

--- a/packages/server/src/beatmap/beatmap-snapshot.service.ts
+++ b/packages/server/src/beatmap/beatmap-snapshot.service.ts
@@ -1,0 +1,65 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { BeatmapSnapshotEntity } from './beatmap-snapshot.entity';
+import { Repository } from 'typeorm';
+import { BeatmapEntity } from './beatmap.entity';
+import { BeatmapData } from '@osucad/common';
+
+@Injectable()
+export class BeatmapSnapshotService {
+  constructor(
+    @InjectRepository(BeatmapSnapshotEntity)
+    private readonly repository: Repository<BeatmapSnapshotEntity>,
+  ) {}
+
+  private readonly snapshotCombineThreshold = /* 5 minutes */ 5 * 60 * 1000;
+
+  async createSnapshot(
+    beatmap: BeatmapEntity,
+    data: BeatmapData,
+  ): Promise<BeatmapSnapshotEntity> {
+    return this.repository.manager.transaction(async (em) => {
+      const existingSnapshot = await this.repository.findOne({
+        where: {
+          beatmap: {
+            id: beatmap.id,
+          },
+        },
+        order: { timestamp: 'DESC' },
+      });
+
+      if (existingSnapshot) {
+        const age = existingSnapshot.timestamp.getTime() - Date.now();
+        if (age < this.snapshotCombineThreshold) {
+          existingSnapshot.data = data;
+          existingSnapshot.version = data.version ?? 1;
+          existingSnapshot.timestamp = new Date();
+
+          await em.save(existingSnapshot);
+          return existingSnapshot;
+        }
+      }
+
+      const snapshot = new BeatmapSnapshotEntity();
+      snapshot.beatmap = beatmap;
+      snapshot.data = data;
+      snapshot.version = data.version ?? 1;
+
+      await em.save(snapshot);
+      return snapshot;
+    });
+  }
+
+  async getLatestSnapshot(
+    beatmap: BeatmapEntity,
+  ): Promise<BeatmapSnapshotEntity | null> {
+    return this.repository.findOne({
+      where: {
+        beatmap: {
+          id: beatmap.id,
+        },
+      },
+      order: { timestamp: 'DESC' },
+    });
+  }
+}

--- a/packages/server/src/beatmap/beatmap.entity.ts
+++ b/packages/server/src/beatmap/beatmap.entity.ts
@@ -26,9 +26,6 @@ export class BeatmapEntity {
   @ManyToOne(() => MapsetEntity, (mapset) => mapset.beatmaps)
   mapset: MapsetEntity;
 
-  @Column('json')
-  data: BeatmapData;
-
   getInfo(): BeatmapInfo {
     return {
       id: this.uuid,

--- a/packages/server/src/beatmap/beatmap.module.ts
+++ b/packages/server/src/beatmap/beatmap.module.ts
@@ -12,6 +12,7 @@ import { BeatmapExportService } from './beatmap-export.service';
 import { EditorModule } from '../editor/editor.module';
 import { AssetsModule } from '../assets/assets.module';
 import { BeatmapSnapshotEntity } from './beatmap-snapshot.entity';
+import { BeatmapSnapshotService } from './beatmap-snapshot.service';
 
 @Module({
   imports: [
@@ -26,8 +27,13 @@ import { BeatmapSnapshotEntity } from './beatmap-snapshot.entity';
     forwardRef(() => EditorModule),
     forwardRef(() => AssetsModule),
   ],
-  providers: [BeatmapService, BeatmapImportService, BeatmapExportService],
+  providers: [
+    BeatmapService,
+    BeatmapImportService,
+    BeatmapExportService,
+    BeatmapSnapshotService,
+  ],
   controllers: [MapsetController],
-  exports: [BeatmapService],
+  exports: [BeatmapService, BeatmapSnapshotService],
 })
 export class BeatmapModule {}

--- a/packages/server/src/beatmap/beatmap.module.ts
+++ b/packages/server/src/beatmap/beatmap.module.ts
@@ -11,6 +11,7 @@ import { EditorSessionEntity } from '../editor/editor-session.entity';
 import { BeatmapExportService } from './beatmap-export.service';
 import { EditorModule } from '../editor/editor.module';
 import { AssetsModule } from '../assets/assets.module';
+import { BeatmapSnapshotEntity } from './beatmap-snapshot.entity';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { AssetsModule } from '../assets/assets.module';
       BeatmapEntity,
       ParticipantEntity,
       EditorSessionEntity,
+      BeatmapSnapshotEntity,
     ]),
     UserModule,
     forwardRef(() => EditorModule),

--- a/packages/server/src/beatmap/beatmap.service.ts
+++ b/packages/server/src/beatmap/beatmap.service.ts
@@ -9,6 +9,7 @@ import { ParticipantEntity } from './participant.entity';
 import { BeatmapData } from '@osucad/common';
 import { UserEntity } from '../users/user.entity';
 import { EditorSessionEntity } from '../editor/editor-session.entity';
+import { BeatmapSnapshotService } from './beatmap-snapshot.service';
 
 @Injectable()
 export class BeatmapService {
@@ -21,6 +22,7 @@ export class BeatmapService {
     private readonly participantRepository: Repository<ParticipantEntity>,
     @InjectRepository(EditorSessionEntity)
     private readonly sessionRepository: Repository<EditorSessionEntity>,
+    private readonly snapshotService: BeatmapSnapshotService,
   ) {}
 
   async createMapset(mapset: MapsetEntity) {
@@ -99,6 +101,7 @@ export class BeatmapService {
           id: true,
           name: true,
           starRating: true,
+          uuid: true,
         },
       },
       order: {
@@ -127,8 +130,8 @@ export class BeatmapService {
   }
 
   async save(beatmap: BeatmapEntity, data: BeatmapData) {
-    beatmap.data = data;
     await this.beatmapRepository.save(beatmap);
+    await this.snapshotService.createSnapshot(beatmap, data);
   }
 
   findLastEditedBeatmaps(user: UserEntity) {

--- a/packages/server/src/editor/editor.room.ts
+++ b/packages/server/src/editor/editor.room.ts
@@ -2,6 +2,7 @@ import { UserEntity } from '../users/user.entity';
 import { Socket } from 'socket.io';
 import {
   Beatmap,
+  BeatmapData,
   ClientMessages,
   CommandContext,
   ControlPointManager,
@@ -26,7 +27,10 @@ export class EditorRoom {
 
   hasUnsavedChanges = false;
 
-  constructor(public entity: BeatmapEntity) {
+  constructor(
+    public entity: BeatmapEntity,
+    snapshot: BeatmapData,
+  ) {
     const {
       hitObjects,
       controlPoints,
@@ -38,7 +42,7 @@ export class EditorRoom {
       general,
       hitSounds = { layers: defaultHitSoundLayers() },
       version,
-    } = entity.data;
+    } = snapshot;
 
     this.beatmap = new Beatmap({
       id: entity.uuid,

--- a/packages/server/src/tasks/migrations/1708736838564-beatmap-snapshots.ts
+++ b/packages/server/src/tasks/migrations/1708736838564-beatmap-snapshots.ts
@@ -5,7 +5,7 @@ export class BeatmapSnapshots1708736838564 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE TABLE \`beatmap_snapshot\` (\`id\` varchar(36) NOT NULL, \`timestamp\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, \`version\` int NOT NULL, \`data\` json NOT NULL, \`beatmapId\` int NULL, INDEX \`IDX_9f335b3173d84e6675558aeb51\` (\`timestamp\`), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
+      `CREATE TABLE \`beatmap_snapshot\` (\`id\` varchar(36) NOT NULL, \`timestamp\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, \`createDate\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, \`version\` int NOT NULL, \`data\` json NOT NULL, \`beatmapId\` int NULL, INDEX \`IDX_9f335b3173d84e6675558aeb51\` (\`timestamp\`), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
     );
     await queryRunner.query(
       `ALTER TABLE \`beatmap_snapshot\` ADD CONSTRAINT \`FK_653dc96bbbb6d8aa57a6a0e7940\` FOREIGN KEY (\`beatmapId\`) REFERENCES \`beatmaps\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,

--- a/packages/server/src/tasks/migrations/1708736838564-beatmap-snapshots.ts
+++ b/packages/server/src/tasks/migrations/1708736838564-beatmap-snapshots.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class BeatmapSnapshots1708736838564 implements MigrationInterface {
+  name = 'BeatmapSnapshots1708736838564';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE \`beatmap_snapshot\` (\`id\` varchar(36) NOT NULL, \`timestamp\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, \`version\` int NOT NULL, \`data\` json NOT NULL, \`beatmapId\` int NULL, INDEX \`IDX_9f335b3173d84e6675558aeb51\` (\`timestamp\`), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`beatmap_snapshot\` ADD CONSTRAINT \`FK_653dc96bbbb6d8aa57a6a0e7940\` FOREIGN KEY (\`beatmapId\`) REFERENCES \`beatmaps\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `
+            INSERT INTO \`beatmap_snapshot\` (\`id\`, \`version\`, \`data\`, \`beatmapId\`)
+                SELECT
+                    UUID(),
+                    IFNULL(JSON_EXTRACT(\`data\`, "$.version"), 1),
+                    \`data\`,
+                    \`id\`
+            FROM \`beatmaps\`
+            `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`beatmap_snapshot\` DROP FOREIGN KEY \`FK_653dc96bbbb6d8aa57a6a0e7940\``,
+    );
+    await queryRunner.query(
+      `DROP INDEX \`IDX_9f335b3173d84e6675558aeb51\` ON \`beatmap_snapshot\``,
+    );
+    await queryRunner.query(`DROP TABLE \`beatmap_snapshot\``);
+  }
+}

--- a/packages/server/src/tasks/migrations/1708736838564-beatmap-snapshots.ts
+++ b/packages/server/src/tasks/migrations/1708736838564-beatmap-snapshots.ts
@@ -21,6 +21,9 @@ export class BeatmapSnapshots1708736838564 implements MigrationInterface {
             FROM \`beatmaps\`
             `,
     );
+    await queryRunner.query(
+      `ALTER TABLE \`beatmaps\` CHANGE \`data\` \`data\` json NULL`,
+    );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {


### PR DESCRIPTION
Adds beatmap snapshots, to allow reading an earlier state of beatmaps in the future. If last snapshot was created less than 5 minutes ago it will be updated instead of creating a new one, to save some disk space.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new system for handling beatmap snapshots, enhancing the management and export of beatmaps.
- **Refactor**
	- Modified beatmap import and export services to utilize the new snapshot functionality.
	- Updated editor room creation to leverage beatmap snapshots for improved data handling.
- **Database Changes**
	- Implemented a migration to create a `beatmap_snapshot` table and update existing beatmap data to support snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->