### PR TITLE
Configure line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=lf
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.ts text
+*.vue text
+*.js text
+*.json text
+*.html text
+*.css text
+*.scss text
+*.md text
+*.yml text
+*.yaml text
+*.xml text
+*.svg text
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.jpeg binary


### PR DESCRIPTION
Switching to LF because linter is being annoying af about it on windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Chores**
	- Implemented a `.gitattributes` file to standardize line ending normalization and binary file handling across different environments.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->