### PR TITLE
Feat: Add chat

### DIFF
--- a/packages/client/src/editor/chat.ts
+++ b/packages/client/src/editor/chat.ts
@@ -1,0 +1,39 @@
+import { ChatMessage } from '@osucad/common';
+import { EditorSocket } from '@/editor/editorSocket.ts';
+
+export class ChatManager {
+  constructor(private readonly socket: EditorSocket) {
+    socket.on('chatHistory', (history) => {
+      this._messages.value = history.messages;
+    });
+
+    socket.on('chatMessageCreated', (message) => {
+      this.onMessageCreated(message);
+    });
+
+    socket.on('chatMessageDeleted', (messageId) => {
+      this.onMessageDeleted(messageId);
+    });
+  }
+
+  private _messages = ref<ChatMessage[]>([]);
+
+  get messages() {
+    return this._messages.value;
+  }
+
+  private onMessageCreated(message: ChatMessage) {
+    this._messages.value.push(message);
+  }
+
+  private onMessageDeleted(messageId: number) {
+    const index = this._messages.value.findIndex((m) => m.id === messageId);
+    if (index !== -1) {
+      this._messages.value.splice(index, 1);
+    }
+  }
+
+  sendMessage(content: string) {
+    this.socket.emit('sendChatMessage', content);
+  }
+}

--- a/packages/client/src/editor/components/BeatmapEditor.vue
+++ b/packages/client/src/editor/components/BeatmapEditor.vue
@@ -13,6 +13,7 @@ import { App } from '@capacitor/app';
 import { useRouter } from 'vue-router';
 import { EditorPopoverHost } from '@/editor/components/popover';
 import ShareButton from '@/editor/components/ShareButton.vue';
+import ChatBox from '@/editor/components/ChatBox.vue';
 
 const { joinKey } = defineProps<{
   joinKey: string;
@@ -91,6 +92,7 @@ const viewportInitialized = ref(false);
       <Teleport to="#navbar-end">
         <ShareButton />
       </Teleport>
+      <ChatBox />
     </template>
 
     <div
@@ -110,7 +112,6 @@ const viewportInitialized = ref(false);
       </div>
     </div>
   </div>
-
   <PreferencesOverlay />
 </template>
 

--- a/packages/client/src/editor/components/ChatBox.vue
+++ b/packages/client/src/editor/components/ChatBox.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import ChatMessage from './ChatMessage.vue';
+import { useEditor } from '@/editor/editorContext.ts';
+import { QScrollArea } from 'quasar';
+
+const currentMessage = ref('');
+
+const { chat } = useEditor();
+
+const showChat = useLocalStorage('showChat', true);
+
+function sendMessage(evt: KeyboardEvent) {
+  if (evt.shiftKey) return;
+
+  chat.sendMessage(currentMessage.value);
+
+  currentMessage.value = '';
+  evt.preventDefault();
+}
+
+const chatScrollArea = ref<QScrollArea | null>(null);
+
+watch(chat.messages, () => {
+  const el = chatScrollArea.value as QScrollArea;
+  if (el) {
+    nextTick(() => {
+      el.setScrollPercentage('vertical', 100);
+    });
+  }
+});
+
+onMounted(() => {
+  const el = chatScrollArea.value as QScrollArea;
+  if (el) {
+    el.setScrollPercentage('vertical', 100);
+  }
+});
+</script>
+
+<template>
+  <q-card class="chat-box" flat v-if="showChat">
+    <q-card-section>
+      <div class="row">
+        <div class="text-h6">
+          <q-icon icon="chat" />
+          Chat
+        </div>
+        <q-space />
+        <q-btn icon="close" flat round dense @click="showChat = false" />
+      </div>
+    </q-card-section>
+
+    <q-scroll-area class="chat-messages" ref="chatScrollArea">
+      <q-list>
+        <chat-message
+          v-for="message in chat.messages"
+          :key="message.id"
+          :message="message"
+        />
+      </q-list>
+    </q-scroll-area>
+    <div class="row">
+      <q-input
+        v-model="currentMessage"
+        dense
+        class="flex-1"
+        filled
+        type="textarea"
+        autogrow
+        @keydown.enter="sendMessage"
+      />
+    </div>
+  </q-card>
+  <q-btn
+    class="chat-button"
+    v-else
+    color="dark"
+    icon="chat"
+    @click="showChat = true"
+  />
+</template>
+
+<style lang="scss" scoped>
+.chat-box {
+  width: 350px;
+  position: absolute;
+  right: 5px;
+  display: flex;
+  flex-direction: column;
+  height: 400px;
+  bottom: 90px;
+}
+
+.chat-button {
+  position: absolute;
+  right: 5px;
+  bottom: 90px;
+}
+
+.chat-messages {
+  flex: 1;
+}
+</style>

--- a/packages/client/src/editor/components/ChatBox.vue
+++ b/packages/client/src/editor/components/ChatBox.vue
@@ -67,6 +67,7 @@ onMounted(() => {
         filled
         type="textarea"
         autogrow
+        :maxlength="500"
         @keydown.enter="sendMessage"
       />
     </div>

--- a/packages/client/src/editor/components/ChatFragment.vue
+++ b/packages/client/src/editor/components/ChatFragment.vue
@@ -1,0 +1,81 @@
+<script lang="ts">
+import { PropType } from 'vue';
+import { ChatFragment } from '@osucad/common';
+
+export default defineComponent({
+  props: {
+    fragment: {
+      type: Object as PropType<ChatFragment>,
+      required: true,
+    },
+    ownUserId: Number,
+  },
+  emits: ['timestamp-click'],
+  methods: {
+    onTimestampClick() {
+      if (this.fragment.type === 'timestamp') {
+        this.$emit('timestamp-click', {
+          time: this.fragment.time,
+          objects: this.fragment.objects,
+        });
+      }
+    },
+  },
+  render() {
+    switch (this.fragment.type) {
+      case 'code':
+        return h('span', { class: 'code' }, this.fragment.text);
+      case 'timestamp':
+        return h(
+          'span',
+          {
+            class: 'timestamp',
+            onClick: this.onTimestampClick,
+          },
+          this.fragment.text,
+        );
+      case 'mention':
+        return h(
+          'span',
+          {
+            class: {
+              mention: true,
+              'mention-own': this.fragment.mention === this.ownUserId,
+            },
+          },
+          this.fragment.text,
+        );
+      case 'newline':
+        return h('span', '\n');
+      default:
+        return h('span', this.fragment.text!);
+    }
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.code {
+  background-color: rgba(white, 0.2);
+  border-radius: 3px;
+  padding: 0.25rem;
+  font-family: monospace;
+}
+
+.timestamp {
+  background-color: rgba(white, 0.2);
+  border-radius: 3px;
+  padding: 0.25rem;
+  font-family: monospace;
+  color: $primary;
+  cursor: pointer;
+}
+
+.mention {
+  font-weight: bold;
+
+  &.mention-own {
+    color: $primary;
+  }
+}
+</style>

--- a/packages/client/src/editor/components/ChatFragment.vue
+++ b/packages/client/src/editor/components/ChatFragment.vue
@@ -58,14 +58,14 @@ export default defineComponent({
 .code {
   background-color: rgba(white, 0.2);
   border-radius: 3px;
-  padding: 0.25rem;
+  padding: 0.125rem;
   font-family: monospace;
 }
 
 .timestamp {
   background-color: rgba(white, 0.2);
   border-radius: 3px;
-  padding: 0.25rem;
+  padding: 0.125rem;
   font-family: monospace;
   color: $primary;
   cursor: pointer;

--- a/packages/client/src/editor/components/ChatMessage.vue
+++ b/packages/client/src/editor/components/ChatMessage.vue
@@ -1,0 +1,141 @@
+<script setup lang="ts">
+import { ChatMessage } from '@osucad/common';
+import ChatFragment from './ChatFragment.vue';
+import { useEditor } from '@/editor/editorContext.ts';
+import { match } from 'variant';
+
+const props = defineProps<{
+  message: ChatMessage;
+}>();
+
+const isServer = computed(() => props.message.user === 'server');
+const username = computed(() => {
+  if (props.message.user === 'server') {
+    return 'server';
+  }
+  return props.message.user.username;
+});
+const avatarUrl = computed(() => {
+  if (props.message.user === 'server') {
+    return undefined;
+  }
+  return props.message.user.avatarUrl;
+});
+
+const { connectedUsers } = useEditor();
+
+const ownUserId = computed(() => connectedUsers.ownUser.value?.id);
+
+const mentionsMe = computed(() =>
+  props.message.message.some(
+    (it) => it.type === 'mention' && it.mention === ownUserId.value,
+  ),
+);
+
+const { clock, beatmapManager, selection } = useEditor();
+
+function onTimestampClick(timestamp: { time: number; objects: number[] }) {
+  if (isNaN(timestamp.time)) return;
+  clock.seek(timestamp.time);
+
+  selection.clear();
+
+  let hitObjects = beatmapManager.hitObjects.hitObjects;
+  const startIndex = hitObjects.findIndex(
+    (it) => it.startTime >= timestamp.time,
+  );
+  if (startIndex === -1) return;
+  hitObjects = hitObjects.slice(startIndex);
+  const comboNumbers = [...timestamp.objects];
+  for (const obj of hitObjects) {
+    if (comboNumbers.length === 0) break;
+    if (comboNumbers[0] === obj.indexInCombo + 1) {
+      selection.add(obj);
+      comboNumbers.shift();
+    }
+  }
+}
+
+const timestamp = computed(() => {
+  const date = new Date(props.message.timestamp);
+  const locale = navigator.language;
+  return date.toLocaleString(locale, {
+    hour: 'numeric',
+    minute: 'numeric',
+  });
+});
+
+function onUsernameClicked() {
+  const user = props.message.user;
+  if (user === 'server') return;
+  if (user.id === ownUserId.value) return;
+  const session = connectedUsers.users.value.find((it) => it.id === user.id);
+  if (session) {
+    const activity = session.presence.activity;
+    if (activity) {
+      match(activity, {
+        composeScreen({ currentTime }) {
+          clock.seek(currentTime);
+        },
+        default() {},
+      });
+    }
+  }
+}
+</script>
+
+<template>
+  <q-item v-once :class="{ 'mentions-me': mentionsMe }">
+    <q-item-section>
+      <div class="row">
+        <div class="text-bold username" :class="{ server: isServer }">
+          <q-avatar class="avatar" size="28px" @click="onUsernameClicked">
+            <img v-if="avatarUrl" :src="avatarUrl" />
+          </q-avatar>
+          {{ username }}
+        </div>
+        <q-space />
+        <div class="text-caption">{{ timestamp }}</div>
+      </div>
+      <pre
+        class="message-content"
+      ><chat-fragment v-for="(fragment, index) in message.message"
+                      :key="index"
+                      :fragment="fragment"
+                      :own-user-id="ownUserId"
+                      @timestamp-click="onTimestampClick"
+      /></pre>
+    </q-item-section>
+  </q-item>
+</template>
+
+<style lang="scss" scoped>
+.mentions-me {
+  background-color: rgba($primary, 0.1);
+}
+
+pre {
+  font-family: $font-family;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.avatar {
+  margin-right: 0.5rem;
+}
+
+.username {
+  cursor: pointer;
+
+  &.server {
+    color: $primary;
+    user-select: none;
+    cursor: default;
+  }
+}
+
+.message-content {
+  padding-left: calc(28px + 0.5rem);
+  margin: 0;
+}
+</style>

--- a/packages/client/src/editor/editorClient.ts
+++ b/packages/client/src/editor/editorClient.ts
@@ -15,6 +15,7 @@ import { EditorSocket } from '@/editor/editorSocket.ts';
 import { EditorContext, globalEditor } from '@/editor/editorContext.ts';
 import fontUrl from '@fontsource/nunito-sans/files/nunito-sans-cyrillic-400-normal.woff2';
 import { Ref } from 'vue';
+import { ChatManager } from '@/editor/chat.ts';
 
 export async function createEditorClient(
   joinKey: string,
@@ -50,6 +51,7 @@ export async function createEditorClient(
   const mods = [] as Mod[];
   const commandManager = new CommandManager(beatmapManager, socket);
   const { preferences, loaded: preferencesLoaded } = usePreferences();
+  const chat = new ChatManager(socket);
 
   await Promise.all([
     receiveRoomState(socket),
@@ -95,6 +97,7 @@ export async function createEditorClient(
     audioManager,
     preferences,
     tools,
+    chat,
   };
 
   globalEditor.value = ctx;

--- a/packages/client/src/editor/editorContext.ts
+++ b/packages/client/src/editor/editorContext.ts
@@ -10,6 +10,7 @@ import { Preferences } from '@osucad/common';
 import { ToolManager } from '@/editor/tools/toolManager.ts';
 import { InjectionKey } from 'vue';
 import { EditorSocket } from '@/editor/editorSocket.ts';
+import { ChatManager } from '@/editor/chat.ts';
 
 export interface EditorContext {
   socket: EditorSocket;
@@ -23,6 +24,7 @@ export interface EditorContext {
   audioManager: AudioManager;
   preferences: Preferences;
   tools: ToolManager;
+  chat: ChatManager;
 }
 
 export const EditorContext: InjectionKey<EditorContext> = Symbol('editor');

--- a/packages/client/src/editor/interaction/copyPasteInteractions.ts
+++ b/packages/client/src/editor/interaction/copyPasteInteractions.ts
@@ -1,23 +1,56 @@
 import {
   EditorCommand,
+  HitObject,
   hitObjectId,
   SerializedHitObject,
 } from '@osucad/common';
 import { EditorContext } from '@/editor/editorContext.ts';
 
 export function copyPasteInteractions(editor: EditorContext) {
+  function copyTimestamp(e: ClipboardEvent, hitObjects: HitObject[]) {
+    const time = hitObjects[0]?.startTime ?? editor.clock.currentTime;
+    const minutes = Math.floor(time / 60000);
+    const seconds = Math.floor((time % 60000) / 1000);
+    const milliseconds = Math.floor(time % 1000);
+
+    const timestamp = [
+      minutes.toString().padStart(2, '0'),
+      seconds.toString().padStart(2, '0'),
+      milliseconds.toString().padStart(3, '0'),
+    ].join(':');
+
+    let comboInfo = '';
+
+    if (hitObjects.length > 0) {
+      const comboNumbers = hitObjects.map((it) => it.indexInCombo + 1);
+      comboInfo = ` (${comboNumbers.join(',')})`;
+    }
+
+    e.clipboardData!.setData('text/plain', `${timestamp}${comboInfo} - `);
+  }
+
   useEventListener('copy', (e) => {
+    if (shouldIgnore(e)) return;
+
     const hitObjects = editor.beatmapManager.hitObjects.hitObjects.filter(
       (it) => it.isSelected,
     );
+
+    hitObjects.sort((a, b) => a.startTime - b.startTime);
+
     e.clipboardData!.setData(
       'osucad/hitobjects',
       JSON.stringify(hitObjects.map((it) => it.serialize())),
     );
+
+    copyTimestamp(e, hitObjects);
+
     e.preventDefault();
   });
 
   useEventListener('cut', (e) => {
+    if (shouldIgnore(e)) return;
+
     const hitObjects = editor.beatmapManager.hitObjects.hitObjects.filter(
       (it) => it.isSelected,
     );
@@ -31,10 +64,15 @@ export function copyPasteInteractions(editor: EditorContext) {
       );
     }
     editor.commandManager.commit();
+
+    copyTimestamp(e, hitObjects);
+
     e.preventDefault();
   });
 
   useEventListener('paste', (e) => {
+    if (shouldIgnore(e)) return;
+
     const data = e.clipboardData!.getData('osucad/hitobjects');
     if (!data) return;
 
@@ -65,4 +103,16 @@ export function copyPasteInteractions(editor: EditorContext) {
     editor.selection.clear();
     editor.selection.selectAll(createdHitObjects);
   });
+}
+
+function shouldIgnore(event: ClipboardEvent): boolean {
+  if (
+    event.target instanceof HTMLInputElement ||
+    event.target instanceof HTMLTextAreaElement
+  ) {
+    return true;
+  }
+  if (document.querySelector('.q-dialog')) return true;
+
+  return false;
 }

--- a/packages/common/src/protocol/chat.ts
+++ b/packages/common/src/protocol/chat.ts
@@ -6,6 +6,14 @@ export interface ChatHistory {
 
 export interface ChatMessage {
   id: number;
-  user: UserInfo;
-  message: string;
+  user: UserInfo | 'server';
+  timestamp: number;
+  message: ChatFragment[];
 }
+
+export type ChatFragment =
+  | { text: string; type?: undefined }
+  | { type: 'newline' }
+  | { text: string; type: 'mention'; mention: number }
+  | { text: string; type: 'code' }
+  | { text: string; type: 'timestamp'; time: number; objects: number[] };

--- a/packages/common/src/protocol/client.ts
+++ b/packages/common/src/protocol/client.ts
@@ -12,6 +12,8 @@ export interface ClientMessages {
 
   deleteChatMessage(id: number): void;
 
+  sendCursorChat(message: string): void;
+
   setPresence(presence: Presence): void;
 
   commands(commands: Uint8Array): void;

--- a/packages/common/src/protocol/server.ts
+++ b/packages/common/src/protocol/server.ts
@@ -24,6 +24,8 @@ export interface ServerMessages {
 
   chatMessageDeleted(id: number): void;
 
+  cursorChatCreated(sessionId: number, message: string): void;
+
   userActivity(sessionId: number, activity: UserActivity): void;
 
   commands(commands: Uint8Array, sessionId: number): void;

--- a/packages/server/src/editor/handlers/chat.handler.ts
+++ b/packages/server/src/editor/handlers/chat.handler.ts
@@ -45,7 +45,6 @@ export class ChatHandler extends MessageHandler {
     let currentFragment = '';
 
     const timestampMatches = [...message.matchAll(timestampRegex)];
-    console.log([...timestampMatches]);
 
     for (let i = 0; i < message.length; i++) {
       if (timestampMatches[0]?.index === i) {

--- a/packages/server/src/editor/handlers/chat.handler.ts
+++ b/packages/server/src/editor/handlers/chat.handler.ts
@@ -1,7 +1,15 @@
 import { MessageHandler } from './message-handler';
 import { Decorator } from './decorator';
 import { RoomUser } from '../room-user';
-import { BeatmapAccess, ChatHistory, ChatMessage } from '@osucad/common';
+import {
+  BeatmapAccess,
+  ChatFragment,
+  ChatHistory,
+  ChatMessage,
+} from '@osucad/common';
+
+const timestampRegex =
+  /(?<minutes>-?\d{2}):(?<seconds>-?\d{2}):(?<millis>-?\d{3})(?: \((?<combo>\d+(?:,\d+)*)\))?/gm;
 
 export class ChatHandler extends MessageHandler {
   chatHistory: ChatHistory = {
@@ -15,13 +23,86 @@ export class ChatHandler extends MessageHandler {
 
   @Decorator('sendChatMessage')
   onSendChatMessage(roomUser: RoomUser, message: string): void {
+    if (message.startsWith('!')) {
+      this.handleCommand(roomUser, message);
+      return;
+    }
+
     const chatMessage: ChatMessage = {
       id: this.chatHistory.messages.length,
       user: roomUser.user.getInfo(),
-      message,
+      message: this.parseMessage(message),
+      timestamp: Date.now(),
     };
     this.chatHistory.messages.push(chatMessage);
     this.room.broadcast('chatMessageCreated', chatMessage);
+  }
+
+  private parseMessage(message: string): ChatFragment[] {
+    const fragments: ChatFragment[] = [];
+    let currentFragment = '';
+
+    const timestampMatches = [...message.matchAll(timestampRegex)];
+    console.log([...timestampMatches]);
+
+    for (let i = 0; i < message.length; i++) {
+      if (timestampMatches[0]?.index === i) {
+        const match = timestampMatches.shift()!;
+        const minutes = parseInt(match.groups!.minutes);
+        const seconds = parseInt(match.groups!.seconds);
+        const millis = parseInt(match.groups!.millis);
+        const time = minutes * 60000 + seconds * 1000 + millis;
+        const objects = match.groups!.combo
+          ? match.groups!.combo.split(',').map((it) => parseInt(it))
+          : [];
+        fragments.push({
+          text: currentFragment,
+        });
+        currentFragment = '';
+        fragments.push({
+          text: match[0],
+          type: 'timestamp',
+          time,
+          objects,
+        });
+        i += match[0].length - 1;
+        continue;
+      }
+      if (message[i] === '@') {
+        let found = false;
+        for (const user of this.room.users) {
+          const username = user.user.username.toLowerCase();
+          const nextWord = message.substring(i + 1, i + 1 + username.length);
+          const charAfter = message[i + 1 + username.length];
+          if (
+            nextWord.toLowerCase() === username &&
+            (charAfter === undefined || charAfter === ' ' || charAfter === '\n')
+          ) {
+            if (currentFragment.length > 0) {
+              fragments.push({ text: currentFragment });
+              currentFragment = '';
+            }
+            fragments.push({
+              text: `@${user.user.username}`,
+              type: 'mention',
+              mention: user.user.id,
+            });
+            i += username.length;
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          currentFragment += message[i];
+        }
+      } else {
+        currentFragment += message[i];
+      }
+    }
+    if (currentFragment.length > 0) {
+      fragments.push({ text: currentFragment });
+    }
+    return fragments;
   }
 
   @Decorator('deleteChatMessage')
@@ -37,4 +118,144 @@ export class ChatHandler extends MessageHandler {
     this.chatHistory.messages.splice(index, 1);
     this.room.broadcast('chatMessageDeleted', messageId);
   }
+
+  private handleCommand(roomUser: RoomUser, message: string) {
+    const [command, ...args] = message.substring(1).split(' ');
+    switch (command) {
+      case 'help':
+        this.sendHelp(roomUser);
+        break;
+      case 'purge':
+        this.purgeChat(roomUser, args);
+        break;
+      case 'roll':
+        this.roll(roomUser, args);
+        break;
+      case 'kick':
+        this.kickUser(roomUser, args);
+        break;
+      case 'whisper':
+        this.whisper(roomUser, args);
+        break;
+    }
+  }
+
+  private sendHelp(roomUser: RoomUser) {
+    roomUser.socket.emit('chatMessageCreated', {
+      id: this.chatHistory.messages.length,
+      user: 'server',
+      message: helpText,
+      timestamp: Date.now(),
+    });
+  }
+
+  private purgeChat(user: RoomUser, args: string[]) {
+    if (user.access < BeatmapAccess.MapsetOwner) return;
+    if (args.length !== 1) return;
+    const amount = parseInt(args[0]);
+    if (isNaN(amount) || amount < 1) return;
+
+    const deleted = this.chatHistory.messages.slice(-amount);
+    for (const message of deleted) {
+      this.room.broadcast('chatMessageDeleted', message.id);
+    }
+    this.chatHistory.messages = this.chatHistory.messages.slice(
+      0,
+      this.chatHistory.messages.length - amount,
+    );
+  }
+
+  private roll(user: RoomUser, args: string[]) {
+    if (args.length > 1) return;
+    const sides = parseInt(args[0] ?? '100');
+    if (isNaN(sides) || sides < 1) return;
+
+    const result = Math.floor(Math.random() * sides) + 1;
+
+    const message: ChatMessage = {
+      id: this.chatHistory.messages.length,
+      user: 'server',
+      timestamp: Date.now(),
+      message: [
+        {
+          text: `@${user.username}`,
+          type: 'mention',
+          mention: user.user.id,
+        },
+        {
+          text: ` rolls ${result} ${result === 1 ? 'point' : 'points'}`,
+        },
+      ],
+    };
+
+    this.chatHistory.messages.push(message);
+    user.socket.emit('chatMessageCreated', message);
+  }
+
+  private kickUser(roomUser: RoomUser, args: string[]) {
+    if (roomUser.access < BeatmapAccess.MapsetOwner) return;
+    if (args.length !== 1) return;
+    const username = args[0].toLowerCase();
+    const user = this.room.users.find(
+      (u) => u.user.username.toLowerCase() === username,
+    );
+    if (user) {
+      this.room.userHandler.kick(user.user.id);
+    }
+  }
+
+  private whisper(roomUser: RoomUser, args: string[]) {
+    if (args.length < 2) return;
+    const username = args[0].toLowerCase();
+    const users = this.room.users.filter(
+      (u) => u.user.username.toLowerCase() === username,
+    );
+    const message = args.slice(1).join(' ');
+
+    for (const user of users) {
+      user.socket.emit('chatMessageCreated', {
+        id: this.chatHistory.messages.length,
+        timestamp: Date.now(),
+        user: {
+          ...roomUser.user.getInfo(),
+          username: roomUser.username + ' whispers to you:',
+        },
+        message: this.parseMessage(message),
+      });
+    }
+    if (users.length > 0) {
+      roomUser.socket.emit('chatMessageCreated', {
+        id: this.chatHistory.messages.length,
+        timestamp: Date.now(),
+        user: {
+          ...roomUser.user.getInfo(),
+          username: roomUser.username + ` whispers to ${users[0].username}:`,
+        },
+        message: this.parseMessage(message),
+      });
+    }
+  }
 }
+
+const helpText: ChatFragment[] = [
+  { text: 'Available commands:' },
+  { type: 'newline' },
+  { text: '!help', type: 'code' },
+  { text: '  shows this message' },
+  { type: 'newline' },
+  { text: '!whisper [username] [message]', type: 'code' },
+  { type: 'newline' },
+  { text: '  sends a private message to the user' },
+  { type: 'newline' },
+  { text: '!purge [amount]', type: 'code' },
+  { type: 'newline' },
+  { text: '  deletes the last [amount] messages' },
+  { type: 'newline' },
+  { text: '!roll [sides]', type: 'code' },
+  { type: 'newline' },
+  { text: '  rolls a dice with [sides] sides' },
+  { type: 'newline' },
+  { text: '!kick [username]', type: 'code' },
+  { type: 'newline' },
+  { text: '  kicks the user from the room' },
+];

--- a/packages/server/src/editor/handlers/chat.handler.ts
+++ b/packages/server/src/editor/handlers/chat.handler.ts
@@ -23,6 +23,8 @@ export class ChatHandler extends MessageHandler {
 
   @Decorator('sendChatMessage')
   onSendChatMessage(roomUser: RoomUser, message: string): void {
+    if (message.length > 500) return;
+
     if (message.startsWith('!')) {
       this.handleCommand(roomUser, message);
       return;

--- a/packages/server/src/editor/room-user.ts
+++ b/packages/server/src/editor/room-user.ts
@@ -38,4 +38,8 @@ export class RoomUser {
   ) {
     this.socket.emit(message, ...parameters);
   }
+
+  get username() {
+    return this.user.username;
+  }
 }


### PR DESCRIPTION
Adds a chat box where people can send messages while editing a beatmap.
Also comes with a bunch of commands.
- `!whisper [user] [message]` sends a message to just a specific `user`
- `!purge [n]` - will delete the last `n` messages
- `!roll [n=100]` will rill a random number between 0 and `n`
- `!kick [user]` will kick a specified user

Also adds the support to copy timestamps & send them as chat messages, where they are clickable.

![image](https://github.com/minetoblend/osu-cad/assets/8039761/5668f722-c2fd-4c63-8a4d-6cfeb8590718)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Implemented a full-fledged chat system in the editor interface with:
        - Chat manager for message management.
        - Chat components for messages, chat box, and fragments.
        - Enhanced editor interactions for timestamp navigation and message formatting.
    - Added server-side capabilities for parsing chat messages and executing commands.

- **Enhancements**
    - Upgraded copy-paste interactions in the editor to include hit objects data and timestamps.

- **Refactor**
    - Integrated chat features into the editor's client and context setup for improved chat functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->