### PR TITLE
Disable background blur by default

### DIFF
--- a/packages/common/src/types/preferences.ts
+++ b/packages/common/src/types/preferences.ts
@@ -92,7 +92,7 @@ export function defaultPreferences(): Preferences {
         opacity: 50,
       },
       backgroundDim: 50,
-      backgroundBlur: 25,
+      backgroundBlur: 0,
       snapping: {
         blanket: {
           enabled: true,


### PR DESCRIPTION
Shouldn't be enabled by default since a lot of people probably don't wanna use it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the default background blur value to improve visibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->